### PR TITLE
Rename NoIdempotencyKeyException class to be more relevant

### DIFF
--- a/spec/Riskio/IdempotencyModule/IdempotencyKeyExtractorSpec.php
+++ b/spec/Riskio/IdempotencyModule/IdempotencyKeyExtractorSpec.php
@@ -39,7 +39,7 @@ class IdempotencyKeyExtractorSpec extends ObjectBehavior
     {
         $httpRequest = $this->createHttpRequestWithoutIdempotencyKey();
 
-        $this->shouldThrow(Exception\NoIdempotencyKeyException::class)
+        $this->shouldThrow(Exception\NoIdempotencyKeyHeaderException::class)
             ->duringExtract($httpRequest);
     }
 

--- a/src/Exception/NoIdempotencyKeyException.php
+++ b/src/Exception/NoIdempotencyKeyException.php
@@ -1,9 +1,0 @@
-<?php
-declare(strict_types=1);
-
-namespace Riskio\IdempotencyModule\Exception;
-
-class NoIdempotencyKeyException extends RuntimeException implements ExceptionInterface
-{
-    protected $message = 'No idempotent key';
-}

--- a/src/Exception/NoIdempotencyKeyHeaderException.php
+++ b/src/Exception/NoIdempotencyKeyHeaderException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Riskio\IdempotencyModule\Exception;
+
+class NoIdempotencyKeyHeaderException extends RuntimeException implements ExceptionInterface
+{
+    protected $message = 'No idempotency key HTTP header';
+}

--- a/src/IdempotencyKeyExtractor.php
+++ b/src/IdempotencyKeyExtractor.php
@@ -20,7 +20,7 @@ class IdempotencyKeyExtractor
     public function extract(RequestInterface $request) : string
     {
         if (!$request->hasHeader($this->idempotencyKeyHeader)) {
-            throw new Exception\NoIdempotencyKeyException();
+            throw new Exception\NoIdempotencyKeyHeaderException();
         }
 
         $idempotencyKey = $request->getHeader($this->idempotencyKeyHeader)[0];

--- a/src/Listener/SaveIdempotentRequestListener.php
+++ b/src/Listener/SaveIdempotentRequestListener.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Riskio\IdempotencyModule\Listener;
 
-use Riskio\IdempotencyModule\Exception\NoIdempotencyKeyException;
+use Riskio\IdempotencyModule\Exception\NoIdempotencyKeyHeaderException;
 use Riskio\IdempotencyModule\IdempotencyService;
 use Zend\EventManager\AbstractListenerAggregate;
 use Zend\EventManager\EventManagerInterface;
@@ -38,7 +38,7 @@ class SaveIdempotentRequestListener extends AbstractListenerAggregate
                 Psr7ServerRequest::fromZend($event->getRequest()),
                 Psr7Response::fromZend($event->getResponse())
             );
-        } catch (NoIdempotencyKeyException $event) {
+        } catch (NoIdempotencyKeyHeaderException $event) {
             return;
         }
     }


### PR DESCRIPTION
Rename ```NoIdempotencyKeyException``` to ```NoIdempotencyKeyHeaderException```.